### PR TITLE
Show issue urls in totals output

### DIFF
--- a/gtimelog2jira.py
+++ b/gtimelog2jira.py
@@ -9,6 +9,7 @@ import operator
 import pathlib
 import re
 import sys
+import urllib.parse
 
 import requests
 
@@ -283,7 +284,12 @@ def human_readable_time(r, cols=False):
     return ' '.join(reversed(result))
 
 
-def show_results(entries, stdout):
+def build_issue_url(jira_url, issue_number):
+    issue_endpoint = "/browse/{}".format(issue_number)
+    return urllib.parse.urljoin(jira_url, issue_endpoint)
+
+
+def show_results(entries, stdout, jira_url):
     totals = {
         'seconds': collections.defaultdict(int),
         'entries': collections.defaultdict(int),
@@ -315,7 +321,9 @@ def show_results(entries, stdout):
         print('TOTALS:', file=stdout)
         for issue, seconds in sorted(totals['seconds'].items()):
             entries = totals['entries'][issue]
-            print('%10s: %8s (%s)' % (issue, human_readable_time(seconds, cols=True), entries), file=stdout)
+            issue_url = build_issue_url(jira_url, issue)
+            time_spent = human_readable_time(seconds, cols=True)
+            print('%10s: %8s (%s), %s' % (issue, time_spent, entries, issue_url), file=stdout)
 
 
 def main(argv=None, stdout=sys.stdout):
@@ -341,7 +349,7 @@ def main(argv=None, stdout=sys.stdout):
         entries = filter_timelog(entries, since=args.since, until=args.until, issue=args.issue)
         entries = sync_with_jira(config['session'], config['api'], entries, dry_run=args.dry_run)
         entries = log_jira_sync(entries, config['jiralog'])
-        show_results(entries, stdout)
+        show_results(entries, stdout, config['url'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
IMHO, it would be easier this way to check the tickets in Jira's web UI
and in case edit the time log manually

e.g.:

```
> env/bin/python gtimelog2jira.py --since 2018-10-01 --dry-run
Enter Jira password for trymas@pov.lt at https://jira.tilaajavastuu.fi/:

ADD: BOL-1654   2018-10-04T16:00+03:00      31m: sync w Team on Jira timelogging [BOL-1654]
ADD: BOL-1655   2018-10-04T16:54+03:00      10m: thinking about implementing `--force` option in gtimelog2jira [BOL-1655]
ADD: BOL-1657   2018-10-04T17:04+03:00      47m: implementing issue urls in output for gtimelog2jira [BOL-1657]

TOTALS:
  BOL-1654:      31m (1), https://jira.tilaajavastuu.fi/browse/BOL-1654
  BOL-1655:      10m (1), https://jira.tilaajavastuu.fi/browse/BOL-1655
  BOL-1657:      47m (1), https://jira.tilaajavastuu.fi/browse/BOL-1657
```