### PR TITLE
Implement aliases for tickets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,10 @@ file. Configuration file example:
     BAR
     BAZ
 
+  [gtimelog2jira:aliases]
+  # catch-all issue for all billed work not attributable to a specific ticket
+  FOO-MISC = FOO-1234
+
 If password is not specified, script will prompt to enter password
 interactively.
 

--- a/tests.py
+++ b/tests.py
@@ -23,9 +23,16 @@ def test_parse_timelog():
         gtimelog2jira.Entry(datetime.datetime(2014, 3, 31, 18, 48),
                             datetime.datetime(2014, 3, 31, 19, 10),
                             'project2: not working on ABC-1 actually **'),
+        gtimelog2jira.Entry(datetime.datetime(2014, 3, 31, 19, 48),
+                            datetime.datetime(2014, 3, 31, 20, 10),
+                            'project2: meeting prep (ABC-MISC)'),
     ]
-    assert list(gtimelog2jira.parse_timelog(entries, ['ABC'], {})) == [
+    aliases = {
+        'ABC-MISC': 'ABC-42',
+    }
+    assert list(gtimelog2jira.parse_timelog(entries, ['ABC'], aliases)) == [
         gtimelog2jira.WorkLog(entries[0], 'ABC-1', 'ABC-1 some work'),
+        gtimelog2jira.WorkLog(entries[-1], 'ABC-42', 'meeting prep (ABC-MISC)'),
     ]
 
 

--- a/tests.py
+++ b/tests.py
@@ -12,6 +12,23 @@ import requests_mock
 import gtimelog2jira
 
 
+def test_parse_timelog():
+    entries = [
+        gtimelog2jira.Entry(datetime.datetime(2014, 3, 31, 14, 48),
+                            datetime.datetime(2014, 3, 31, 17, 10),
+                            'project2: ABC-1 some work'),
+        gtimelog2jira.Entry(datetime.datetime(2014, 3, 31, 17, 48),
+                            datetime.datetime(2014, 3, 31, 18, 10),
+                            'project3: XYZ-1 other work'),
+        gtimelog2jira.Entry(datetime.datetime(2014, 3, 31, 18, 48),
+                            datetime.datetime(2014, 3, 31, 19, 10),
+                            'project2: not working on ABC-1 actually **'),
+    ]
+    assert list(gtimelog2jira.parse_timelog(entries, ['ABC'], {})) == [
+        gtimelog2jira.WorkLog(entries[0], 'ABC-1', 'ABC-1 some work'),
+    ]
+
+
 class Route:
 
     def __init__(self, handler, params=None):


### PR DESCRIPTION
This way when we have long-lived Jira tickets for various overhead tasks, we can refer to them using symbolic names instead of having to remember ticket numbers.